### PR TITLE
Add tests for unexpected end of input

### DIFF
--- a/test/fixtures/end_of_input.coffee
+++ b/test/fixtures/end_of_input.coffee
@@ -1,0 +1,8 @@
+for label in @columnLabels
+  __out.push '\n    <select>\n        <option  value=\'\'>\n            Please select a form field label.\n        </option>\n    </select>\n\n    '
+  if label
+    __out.push '\n        <i class=\'column-alert\' title=\'one\'></i>\n    '
+  else
+    __out.push '\n        <i class=\'column-alert\' title=\'Values in this column will not\'></i>\n    '
+  __out.push '\n'
+__out.push '\n'

--- a/test/fixtures/end_of_input.eco
+++ b/test/fixtures/end_of_input.eco
@@ -1,0 +1,13 @@
+<% for label in @columnLabels: %>
+    <select>
+        <option  value=''>
+            Please select a form field label.
+        </option>
+    </select>
+
+    <% if label: %>
+        <i class='column-alert' title='one'></i>
+    <% else: %>
+        <i class='column-alert' title='Values in this column will not'></i>
+    <% end %>
+<% end %>

--- a/test/test_compile.coffee
+++ b/test/test_compile.coffee
@@ -6,6 +6,10 @@ module.exports =
     test.ok eco.compile fixture("hello.eco")
     test.done()
 
+  "compiling fixtures/end_of_input.eco": (test) ->
+    test.ok eco.compile fixture("end_of_input.eco")
+    test.done()
+
   "compiling fixtures/projects.eco": (test) ->
     test.ok eco.compile fixture("projects.eco")
     test.done()

--- a/test/test_preprocessor.coffee
+++ b/test/test_preprocessor.coffee
@@ -6,6 +6,10 @@ module.exports =
     test.same fixture("hello.coffee"), preprocess fixture("hello.eco")
     test.done()
 
+  "preprocessing fixtures/end_of_input.eco": (test) ->
+    test.same fixture("end_of_input.coffee"), preprocess fixture("end_of_input.eco")
+    test.done()
+
   "preprocessing fixtures/projects.eco": (test) ->
     test.same fixture("projects.coffee"), preprocess fixture("projects.eco")
     test.done()


### PR DESCRIPTION
Add tests to see if this error in https://github.com/dativebase/dative/pull/324

```
Running "eco:files" (eco) task
...
File .tmp/scripts/templates/application-settings-view.js created.
>> Error in app/scripts/templates/application-settings.eco:
>> [stdin]:4:24: error: unexpected end of input
>>     _print _safe '\n' +
```


- [x]  is reproducible in 1.0.3  https://travis-ci.org/github/cesine/eco/jobs/710769130

```
test_compile
(node:5342) [DEP0025] DeprecationWarning: sys is deprecated. Use util instead.
✔ compiling fixtures/hello.eco
✖ compiling fixtures/end_of_input.eco
[stdin]:13:24: error: unexpected end of input
    _print _safe '\n' +
                       
✔ compiling fixtures/projects.eco
✔ compiling fixtures/helpers.eco
✔ parse error throws exception
```

- [x] but not reproducible in master https://travis-ci.org/github/cesine/eco/jobs/710102116

```
test_compiler
✔ compiling fixtures/hello.eco
✔ compiling fixtures/end_of_input.eco
✔ compiling fixtures/projects.eco
✔ compiling fixtures/helpers.eco
✔ parse error throws exception
```